### PR TITLE
Fixing 404 errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && cp error.html dist/error.html",
+    "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -20,7 +20,7 @@ resource "aws_s3_bucket_website_configuration" "website" {
   }
 
   error_document {
-    key = "error.html"
+    key = "index.html"
   }
 }
 


### PR DESCRIPTION
- As s3 doesnt understand react routing , so when 404 redirect to index.html .
- remove additional command on vite build .